### PR TITLE
Add target_timebase support to Variant model and to VariantEditStream.js

### DIFF
--- a/utilities/VariantEditStream.js
+++ b/utilities/VariantEditStream.js
@@ -48,6 +48,11 @@ class VariantEditStream extends Utility {
           descTemplate: 'Blank out the stream\'s target_frame_rate field',
           type: 'boolean',
           conflicts: 'targetFrameRate'
+        }),
+        NewOpt('clearTargetTimebase', {
+          descTemplate: 'Blank out the stream\'s target_timebase field',
+          type: 'boolean',
+          conflicts: 'targetTimebase'
         })
       ]
     }
@@ -67,7 +72,8 @@ class VariantEditStream extends Utility {
         'mapping',
         'multipliers',
         'streamIndex',
-        'targetFrameRate'
+        'targetFrameRate',
+        'targetTimebase'
       ],
       this.args
     )

--- a/utilities/lib/concerns/VariantStreamArgs.js
+++ b/utilities/lib/concerns/VariantStreamArgs.js
@@ -40,6 +40,11 @@ const blueprint = {
       type: 'string',
       coerce: FractionStrModel
     }),
+    NewOpt('targetTimebase', {
+      descTemplate: 'Timebase to use for mezzanine stream',
+      type: 'string',
+      coerce: FractionStrModel
+    }),
     NewOpt('mapping', {
       choices: [
         '2MONO_1STEREO',       // combine 2 mono audio streams into a single stereo audio stream
@@ -81,6 +86,7 @@ const New = () => {
     const file = stream.sources[0].files_api_path
     const streamIndex = stream.sources.map(x => x.stream_index)
     const targetFrameRate = stream.target_frame_rate
+    const targetTimebase = stream.target_timebase
 
     const foundChannelIndexes = stream.sources.map(x => x.channel_index).filter(x=>x)
     const channelIndex = R.isEmpty(foundChannelIndexes)
@@ -104,7 +110,8 @@ const New = () => {
       multipliers,
       role,
       streamIndex,
-      targetFrameRate
+      targetFrameRate,
+      targetTimebase
     }
   }
 
@@ -121,7 +128,8 @@ const New = () => {
       multipliers,
       role,
       streamIndex,
-      targetFrameRate
+      targetFrameRate,
+      targetTimebase
     } = opts
 
     if(!sources[file]) throw Error(`Source '${file}' not found in master. If the file exists in the object, run utilities/MasterUpdateSources.js first.`)
@@ -135,7 +143,8 @@ const New = () => {
       mapping_info: mapping,
       role,
       sources: [],
-      target_frame_rate: targetFrameRate
+      target_frame_rate: targetFrameRate,
+      target_timebase: targetTimebase
     }
 
     const source = sources[file]

--- a/utilities/lib/models/Variant.js
+++ b/utilities/lib/models/Variant.js
@@ -118,6 +118,7 @@ const VariantStreamModel = defObjectModel(
     role: [NonBlankStrModel],
     sources: VariantStreamSourceArrayModel,
     target_frame_rate: [FractionStrModel],
+    target_timebase: [FractionStrModel],
     type: [StreamTypeModel] // older objects may not have a type field
   }
 )


### PR DESCRIPTION
Adds `--target-timebase` and `--clear-target-timebase` args to `VariantEditStream.js`

Updates data validation for master variant streams to support `target_timebase` (allows use of `target_timebase` in the JSON stream definition when using `MasterCreate.js --streams`)

Fixes omission of target_framerate when editing stream